### PR TITLE
Add partition management UI

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -71,7 +71,8 @@ Installwizard::Installwizard(QWidget *parent) :
             createDefaultPartitions(drive);
     });
 }
-   QString Installwizard::getUserHome() {
+
+QString Installwizard::getUserHome() {
     QString userHome;
 
     // Use HOME env variable if not root
@@ -134,7 +135,7 @@ void Installwizard::downloadISO(QProgressBar *progressBar) {
             // Set file permissions: readable by everyone
             QFile::setPermissions(finalIsoPath, QFile::ReadOwner | QFile::WriteOwner | QFile::ReadGroup | QFile::ReadOther);
 
-            QMessageBox::information(this, "Success", "Arch Linux ISO downloaded successfully\nto: " + finalIsoPath + " \nNext is Installing depencies and extracting ISO...");
+            QMessageBox::information(this, "Success", "Arch Linux ISO downloaded successfully\nto: " + finalIsoPath + " \nNext is Installing dependencies and extracting ISO...");
             installDependencies();
 
         } else {

--- a/Installwizard.h
+++ b/Installwizard.h
@@ -26,7 +26,6 @@ private:
     QNetworkAccessManager *networkManager;
     QString selectedDrive;  // 🧠 TRACK THE CURRENT DRIVE
     QString getUserHome();
-    void extracted(QStringList &drives);
     void populateDrives(); // Populate the dropdown with available drives
     void mountPartitions(const QString &drive);
     // Remove the parameter from installGrubAsync since we won't need one.
@@ -36,7 +35,6 @@ private:
     void mountISO();
     void on_installButton_clicked();
     void bindSystemDirectories();
-    void chrootInstallBase();
     void forceUnmount(const QString &mountPoint);
     // Declare the methods that were missing
     QStringList getAvailableDrives();        // Detect available drives

--- a/Installwizard.h
+++ b/Installwizard.h
@@ -41,6 +41,8 @@ private:
     // Declare the methods that were missing
     QStringList getAvailableDrives();        // Detect available drives
     void prepareDrive(const QString &drive);   // Prepare the selected drive
+    void populatePartitionTable(const QString &drive); // new
+    void createDefaultPartitions(const QString &drive); // new example
 };
 
 #endif // INSTALLWIZARD_H

--- a/Installwizard.ui
+++ b/Installwizard.ui
@@ -126,7 +126,7 @@
      <string>Refresh</string>
     </property>
    </widget>
-   <widget class="QPushButton" name="prepareButton">
+  <widget class="QPushButton" name="prepareButton">
     <property name="geometry">
      <rect>
       <x>242</x>
@@ -139,7 +139,7 @@
      <string>Prepare Drive</string>
     </property>
    </widget>
-   <widget class="QPlainTextEdit" name="logWidget">
+  <widget class="QPlainTextEdit" name="logWidget">
     <property name="geometry">
      <rect>
       <x>88</x>
@@ -147,6 +147,67 @@
       <width>300</width>
       <height>125</height>
      </rect>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QWizardPage" name="partitionPage">
+   <property name="title">
+    <string>Partition Layout</string>
+   </property>
+   <widget class="QTreeWidget" name="treePartitions">
+    <column>
+     <property name="text">
+      <string>Name</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Size</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Type</string>
+     </property>
+    </column>
+    <column>
+     <property name="text">
+      <string>Mount</string>
+     </property>
+    </column>
+    <property name="geometry">
+     <rect>
+      <x>40</x>
+      <y>30</y>
+      <width>380</width>
+      <height>180</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="partRefreshButton">
+    <property name="geometry">
+     <rect>
+      <x>80</x>
+      <y>220</y>
+      <width>100</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Refresh</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="createPartButton">
+    <property name="geometry">
+     <rect>
+      <x>220</x>
+      <y>220</y>
+      <width>160</width>
+      <height>30</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Create Default Partitions</string>
     </property>
    </widget>
   </widget>

--- a/Installwizard.ui
+++ b/Installwizard.ui
@@ -43,7 +43,6 @@
       <family>Noto Sans</family>
       <pointsize>12</pointsize>
       <italic>false</italic>
-      <fontweight>DemiBold</fontweight>
      </font>
     </property>
     <property name="styleSheet">


### PR DESCRIPTION
## Summary
- add partition table view and creation function
- connect new UI buttons and wizard page
- update UI layout with `partitionPage`

## Testing
- `qmake ArchHelp.pro` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a92739548332aed0cd928c672d13