### PR TITLE
Fix partition page and drive format workflow

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -46,12 +46,12 @@ Installwizard::Installwizard(QWidget *parent) :
         this, &Installwizard::on_installButton_clicked);
 
     connect(this, &QWizard::currentIdChanged, this, [this](int id) {
-        if (id == 2) { // partition page
+        if (id == 1) { // partition page
             QString drive = ui->driveDropdown->currentText().mid(5);
             if (!drive.isEmpty())
                 populatePartitionTable(drive);
         }
-        if (id == 3) { // user setup page
+        if (id == 2) { // user setup page
             if (ui->comboDesktopEnvironment->count() == 0) {
                 ui->comboDesktopEnvironment->addItems({
                     "GNOME", "KDE Plasma", "XFCE", "LXQt", "Cinnamon", "MATE", "i3"
@@ -72,7 +72,7 @@ Installwizard::Installwizard(QWidget *parent) :
     });
 
     connect(ui->driveDropdown, &QComboBox::currentTextChanged, this, [this](const QString &text) {
-        if (currentId() == 2 && !text.isEmpty() && text != "No drives found")
+        if (currentId() == 1 && !text.isEmpty() && text != "No drives found")
             populatePartitionTable(text.mid(5));
     });
 }
@@ -359,22 +359,33 @@ void Installwizard::createDefaultPartitions(const QString &drive) {
         }
     }
 
+    // Ensure kernel sees new table
+    process.start("/bin/bash", QStringList()
+                                << "-c"
+                                << QString("sudo partprobe %1 && sudo udevadm settle")
+                                       .arg(device));
+    process.waitForFinished();
+
     populatePartitionTable(drive);
 }
 
 
 void Installwizard::mountPartitions(const QString &drive) {
     QProcess process;
-    QString rootPart = QString("/dev/%1").arg(drive + "1");
+    QString bootPart = QString("/dev/%1").arg(drive + "1");
+    QString rootPart = QString("/dev/%1").arg(drive + "2");
 
     // 1. Mount root
     process.start("/bin/bash", { "-c",
                                 QString("sudo mount %1 /mnt").arg(rootPart) });
     process.waitForFinished(-1);
 
-    // 2. Ensure /mnt/boot exists
+    // 2. Ensure /mnt/boot exists and mount boot
     process.start("/bin/bash", { "-c",
                                 "sudo mkdir -p /mnt/boot" });
+    process.waitForFinished(-1);
+    process.start("/bin/bash", { "-c",
+                                QString("sudo mount %1 /mnt/boot").arg(bootPart) });
     process.waitForFinished(-1);
 
     // 3. Copy ISO & extract

--- a/Installwizard.ui
+++ b/Installwizard.ui
@@ -83,73 +83,6 @@
     </property>
    </widget>
   </widget>
-  <widget class="QWizardPage" name="wizardPage_2">
-   <widget class="QLabel" name="label_2">
-    <property name="geometry">
-     <rect>
-      <x>116</x>
-      <y>40</y>
-      <width>251</width>
-      <height>22</height>
-     </rect>
-    </property>
-    <property name="styleSheet">
-     <string notr="true">font: 600 12pt &quot;Noto Sans&quot;;</string>
-    </property>
-    <property name="text">
-     <string>Select a drive for installation</string>
-    </property>
-    <property name="alignment">
-     <set>Qt::AlignmentFlag::AlignCenter</set>
-    </property>
-   </widget>
-   <widget class="QComboBox" name="driveDropdown">
-    <property name="geometry">
-     <rect>
-      <x>176</x>
-      <y>132</y>
-      <width>125</width>
-      <height>30</height>
-     </rect>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="refreshButton">
-    <property name="geometry">
-     <rect>
-      <x>112</x>
-      <y>88</y>
-      <width>125</width>
-      <height>30</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Refresh</string>
-    </property>
-   </widget>
-   <widget class="QPushButton" name="prepareButton">
-    <property name="geometry">
-     <rect>
-      <x>242</x>
-      <y>88</y>
-      <width>125</width>
-      <height>30</height>
-     </rect>
-    </property>
-    <property name="text">
-     <string>Prepare Drive</string>
-    </property>
-   </widget>
-   <widget class="QPlainTextEdit" name="logWidget">
-    <property name="geometry">
-     <rect>
-      <x>88</x>
-      <y>190</y>
-      <width>300</width>
-      <height>125</height>
-     </rect>
-    </property>
-   </widget>
-  </widget>
   <widget class="QWizardPage" name="partitionPage">
    <widget class="QLabel" name="driveLabel">
     <property name="geometry">
@@ -226,23 +159,88 @@
      <string>Create Default Partitions</string>
     </property>
    </widget>
-   <widget class="QLabel" name="label_5">
-    <property name="geometry">
-     <rect>
-      <x>190</x>
-      <y>8</y>
-      <width>99</width>
-      <height>25</height>
-     </rect>
-    </property>
-    <property name="styleSheet">
-     <string notr="true">font: 600 12pt &quot;Noto Sans&quot;;</string>
-    </property>
-    <property name="text">
-     <string>Partitioning</string>
-    </property>
+    <widget class="QLabel" name="label_5">
+     <property name="geometry">
+      <rect>
+       <x>190</x>
+       <y>8</y>
+       <width>99</width>
+       <height>25</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font: 600 12pt &quot;Noto Sans&quot;;</string>
+     </property>
+     <property name="text">
+      <string>Partitioning</string>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_2">
+     <property name="geometry">
+      <rect>
+       <x>116</x>
+       <y>40</y>
+       <width>251</width>
+       <height>22</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">font: 600 12pt &quot;Noto Sans&quot;;</string>
+     </property>
+     <property name="text">
+      <string>Select a drive for installation</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignmentFlag::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QComboBox" name="driveDropdown">
+     <property name="geometry">
+      <rect>
+       <x>176</x>
+       <y>132</y>
+       <width>125</width>
+       <height>30</height>
+      </rect>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="refreshButton">
+     <property name="geometry">
+      <rect>
+       <x>112</x>
+       <y>88</y>
+       <width>125</width>
+       <height>30</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Refresh</string>
+     </property>
+    </widget>
+    <widget class="QPushButton" name="prepareButton">
+     <property name="geometry">
+      <rect>
+       <x>242</x>
+       <y>88</y>
+       <width>125</width>
+       <height>30</height>
+      </rect>
+     </property>
+     <property name="text">
+      <string>Prepare Drive</string>
+     </property>
+    </widget>
+    <widget class="QPlainTextEdit" name="logWidget">
+     <property name="geometry">
+      <rect>
+       <x>88</x>
+       <y>190</y>
+       <width>300</width>
+       <height>125</height>
+      </rect>
+     </property>
+    </widget>
    </widget>
-  </widget>
   <widget class="QWizardPage" name="wizardPage_3">
    <widget class="QWidget" name="verticalLayoutWidget">
     <property name="geometry">

--- a/installerworker.cpp
+++ b/installerworker.cpp
@@ -11,7 +11,8 @@ void InstallerWorker::setDrive(const QString &drive) {
 
 void InstallerWorker::run() {
     QProcess process;
-    QString rootPart = QString("/dev/%1").arg(selectedDrive + "1");
+    QString bootPart = QString("/dev/%1").arg(selectedDrive + "1");
+    QString rootPart = QString("/dev/%1").arg(selectedDrive + "2");
 
     emit logMessage("🧙 Starting disk preparation in thread...");
 
@@ -25,9 +26,10 @@ void InstallerWorker::run() {
     // Partition
     emit logMessage("Creating new partition table...");
     QStringList cmds = {
-        QString("sudo parted /dev/%1 --script mklabel msdos").arg(selectedDrive),
-        QString("sudo parted /dev/%1 --script mkpart primary ext4 1MiB 100%").arg(selectedDrive),
-        QString("sudo parted /dev/%1 --script set 1 boot on").arg(selectedDrive)
+        QString("sudo parted /dev/%1 --script mklabel gpt").arg(selectedDrive),
+        QString("sudo parted /dev/%1 --script mkpart ESP fat32 1MiB 513MiB").arg(selectedDrive),
+        QString("sudo parted /dev/%1 --script set 1 esp on").arg(selectedDrive),
+        QString("sudo parted /dev/%1 --script mkpart primary ext4 513MiB 100%%").arg(selectedDrive)
     };
     for (const QString &cmd : cmds) {
         process.start("/bin/bash", {"-c", cmd});
@@ -41,11 +43,22 @@ void InstallerWorker::run() {
     // Refresh table
     emit logMessage("Refreshing partition table...");
     process.start("/bin/bash", {
-        "-c", QString("sudo partprobe /dev/%1 && sudo udevadm trigger").arg(selectedDrive)
+        "-c",
+        QString("sudo partprobe /dev/%1 && sudo udevadm settle").arg(selectedDrive)
     });
     process.waitForFinished();
 
-    // Format partition
+    // Format partitions
+    emit logMessage("Formatting boot partition " + bootPart + " as FAT32...");
+    process.start("/bin/bash", {
+        "-c", QString("sudo mkfs.fat -F32 %1").arg(bootPart)
+    });
+    process.waitForFinished();
+    if (process.exitCode() != 0) {
+        emit errorOccurred("Format failed.");
+        return;
+    }
+
     emit logMessage("Formatting partition " + rootPart + " as ext4...");
     process.start("/bin/bash", {
         "-c", QString("sudo mkfs.ext4 -F -L ROOT %1").arg(rootPart)
@@ -57,8 +70,12 @@ void InstallerWorker::run() {
     }
 
     // Mount
-    emit logMessage("Mounting partition...");
+    emit logMessage("Mounting partitions...");
     process.start("sudo", {"mount", rootPart, "/mnt"});
+    process.waitForFinished();
+    process.start("sudo", {"mkdir", "-p", "/mnt/boot"});
+    process.waitForFinished();
+    process.start("sudo", {"mount", bootPart, "/mnt/boot"});
     process.waitForFinished();
 
     emit logMessage("✅ Drive is ready.");


### PR DESCRIPTION
## Summary
- combine drive selection with partition management
- set partition page as the second wizard page
- update InstallerWorker to use GPT with ESP and root partitions
- ensure kernel sees new partitions and mount boot

## Testing
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_684cdd84ee4c8332b59cd41a45c02ddc