### PR TITLE
Improve usage docs and enforce root check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
 # ArchHelp
-A personal project that can wipe out your system with no warning!!!
+
+**Warning**: this installer performs destructive actions on disks. Make sure
+you understand what it does before running it.
+
+## Running the installer
+
+The application expects to have root privileges because most of the operations
+(partitioning, formatting and mounting) rely on `pkexec`/`sudo`. Launch the
+binary with `sudo` or `pkexec`:
+
+```bash
+sudo ./ArchHelp
+```
+
+Without elevated privileges the formatting step will fail and the ISO will not
+be copied to `/mnt`, which results in the "Arch Linux ISO not found" error on
+the final page.
+
+1. **Download ISO** – press the *Download* button and wait for the progress
+   bar to complete.
+2. **Prepare Drive** – select the target disk and click *Prepare Drive*.
+3. **Create Default Partitions** – optional helper for creating a simple
+   layout.
+4. **Continue through the wizard** – follow the prompts to mount the ISO and
+   install the base system.
+
+Make absolutely sure you selected the correct drive – the installer will wipe
+it completely.

--- a/main.cpp
+++ b/main.cpp
@@ -3,6 +3,15 @@
 
 int main(int argc, char *argv[]) {
     QApplication a(argc, argv);
+
+    // Ensure the installer has the necessary privileges to run
+    if (geteuid() != 0) {
+        QMessageBox::critical(nullptr, "Permissions Error",
+                             "This installer must be run as root.\n"
+                             "Please restart it using 'sudo' or 'pkexec'.");
+        return 1;
+    }
+
     Installwizard wizard;
     wizard.show();
     return a.exec();


### PR DESCRIPTION
## Summary
- document proper usage of the installer
- ensure the wizard is run as root by checking `geteuid`

## Testing
- `qmake -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f806a921c8332b83a97f56fef2ee4