### PR TITLE
Add log views and logging helper

### DIFF
--- a/Installwizard.h
+++ b/Installwizard.h
@@ -36,6 +36,7 @@ private:
     void on_installButton_clicked();
     void forceUnmount(const QString &mountPoint);
     void unmountDrive(const QString &drive);
+    void appendLog(const QString &message);
     // Declare the methods that were missing
     QStringList getAvailableDrives();        // Detect available drives
     void prepareDrive(const QString &drive);   // Prepare the selected drive

--- a/Installwizard.ui
+++ b/Installwizard.ui
@@ -82,6 +82,16 @@
      <number>0</number>
     </property>
    </widget>
+   <widget class="QPlainTextEdit" name="logView2">
+    <property name="geometry">
+     <rect>
+      <x>86</x>
+      <y>190</y>
+      <width>300</width>
+      <height>120</height>
+     </rect>
+    </property>
+   </widget>
   </widget>
   <widget class="QWizardPage" name="partitionPage">
    <widget class="QLabel" name="driveLabel">
@@ -215,6 +225,16 @@
     </property>
     <property name="text">
      <string>Prepare Drive</string>
+    </property>
+   </widget>
+   <widget class="QPlainTextEdit" name="logView3">
+    <property name="geometry">
+     <rect>
+      <x>30</x>
+      <y>310</y>
+      <width>420</width>
+      <height>50</height>
+     </rect>
     </property>
    </widget>
   </widget>


### PR DESCRIPTION
## Summary
- add new log views to installation wizard pages
- log messages to all log views through new `appendLog` helper
- hook worker log output to use the new helper

## Testing
- `xmllint` *(fails: command not found)*
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850b621e07c83329e7aa0ab571f359a