### PR TITLE
Fix ISO unmount

### DIFF
--- a/Installwizard.cpp
+++ b/Installwizard.cpp
@@ -817,9 +817,11 @@ void Installwizard::on_installButton_clicked() {
 
     QProcess process;
 
-    process.start("/bin/bash", QStringList() << "-c" << " sudo umount -Rfl /mn/archiso");
-
-
+    process.start("/bin/bash", QStringList() << "-c" << " sudo umount -Rfl /mnt/archiso");
+    process.waitForFinished(-1);
+    if (process.exitCode() != 0) {
+        qDebug() << "ISO unmount failed:" << process.readAllStandardError();
+    }
 
     connect(thread, &QThread::started, worker, &SystemWorker::run);
     connect(worker, &SystemWorker::logMessage, this, [this](const QString &msg) { appendLog(msg); });


### PR DESCRIPTION
## Summary
- ensure ISO unmount finishes before starting worker thread

## Testing
- `apt-get update`
- `apt-get install -y qtbase5-dev qtchooser`
- `qmake` *(fails due to uic error)*

------
https://chatgpt.com/codex/tasks/task_e_685368f9a3548332a6d3f228682acceb